### PR TITLE
Fixed the version of pony to 0.51.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ## Using the Official Ponylang Docker Images
-ARG FROM_TAG=release
-FROM ponylang/shared-docker-ci-x86-64-unknown-linux-builder:${FROM_TAG}
+ARG FROM_TAG=0.51.1-alpine
+FROM ponylang/ponyc:${FROM_TAG}
 
 WORKDIR /opt/test-runner
 


### PR DESCRIPTION
The "tests/anagram-syntax-error" tests include the pony version number.

Previous to this PR the Dockerfile used "release" which resulted in the latest
version.  Pony just released 0.51.2 so without this PR the current version will
fail CI.