### PR TITLE
Squished nits, Fix pony version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,3 @@ tests/*/results.json
 tests/anagram-all-fail/anagram-all-fail
 tests/anagram-partial-fail/anagram-partial-fail
 tests/anagram-success/anagram-success
-tests/anagram-all-fail/results.json
-tests/anagram-partial-fail/results.json
-tests/anagram-success/results.json
-tests/anagram-syntax-error/results.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ## Using the Official Ponylang Docker Images
-ARG FROM_TAG=release
-FROM ponylang/shared-docker-ci-x86-64-unknown-linux-builder:${FROM_TAG}
+ARG FROM_TAG=0.51.1-alpine
+FROM ponylang/ponyc:${FROM_TAG}
 
 WORKDIR /opt/test-runner
 

--- a/src/pony_test_parser/main.pony
+++ b/src/pony_test_parser/main.pony
@@ -112,12 +112,20 @@ actor Main
       let linenum: USize = rarray.shift()?.usize()?
       try
         mainjsonobj.data("status") = "fail"
-        jsonobj.data("version") = I64(2)
         jsonobj.data("status") = "fail"
-        jsonobj.data("name") = test_source.apply(linenum - 2)?
-        jsonobj.data("test_code") = test_source.apply(linenum - 1)?
-        jsonobj.data("message") = ":".join(rarray.values())
+        jsonobj.data("name") = strip_comment(test_source.apply(linenum - 2)?)
+        jsonobj.data("test_code") = test_source.apply(linenum - 1)?.clone().>lstrip()
+        jsonobj.data("message") = ":".join(rarray.values()).>lstrip()
       end
     end
     jsonobj
+
+  fun strip_comment(str: String): String =>
+    try
+      let idx: ISize = str.find("// ")?
+      str.substring(idx+3)
+    else
+      str
+    end
+
 

--- a/tests/anagram-all-fail/expected_results.json
+++ b/tests/anagram-all-fail/expected_results.json
@@ -1,46 +1,40 @@
 {
   "tests": [
     {
-      "test_code": "    h.assert_array_eq[String](failme, Anagram(\"bobs\", anagrams))",
-      "message": " Assert EQ failed.  Expected ([len=1: failme]) == ([len=0: ])",
+      "test_code": "h.assert_array_eq[String](failme, Anagram(\"bobs\", anagrams))",
+      "message": "Assert EQ failed.  Expected ([len=1: failme]) == ([len=0: ])",
       "status": "fail",
-      "version": 2,
-      "name": "    // Anagram should return an empty array if there are no anagrams"
+      "name": "Anagram should return an empty array if there are no anagrams"
     },
     {
-      "test_code": "    h.assert_array_eq[String](failme, Anagram(\"banana\", anagrams))",
-      "message": " Assert EQ failed.  Expected ([len=1: failme]) == ([len=0: ])",
+      "test_code": "h.assert_array_eq[String](failme, Anagram(\"banana\", anagrams))",
+      "message": "Assert EQ failed.  Expected ([len=1: failme]) == ([len=0: ])",
       "status": "fail",
-      "version": 2,
-      "name": "    // Anagram should ignore same words, those aren't anagrams"
+      "name": "Anagram should ignore same words, those aren't anagrams"
     },
     {
-      "test_code": "    h.assert_array_eq[String](failme, Anagram(\"last\", [\"mass\"]))",
-      "message": " Assert EQ failed.  Expected ([len=1: failme]) == ([len=0: ])",
+      "test_code": "h.assert_array_eq[String](failme, Anagram(\"last\", [\"mass\"]))",
+      "message": "Assert EQ failed.  Expected ([len=1: failme]) == ([len=0: ])",
       "status": "fail",
-      "version": 2,
-      "name": "    // Anagram shouldn't be based on checksum"
+      "name": "Anagram shouldn't be based on checksum"
     },
     {
-      "test_code": "    h.assert_array_eq[String](failme, Anagram(\"nets\", anagrams))",
-      "message": " Assert EQ failed.  Expected ([len=1: failme]) == ([len=1: sent])",
+      "test_code": "h.assert_array_eq[String](failme, Anagram(\"nets\", anagrams))",
+      "message": "Assert EQ failed.  Expected ([len=1: failme]) == ([len=1: sent])",
       "status": "fail",
-      "version": 2,
-      "name": "    // Anagram should return an array of anagrams if present"
+      "name": "Anagram should return an array of anagrams if present"
     },
     {
-      "test_code": "    h.assert_array_eq[String](failme, Anagram(\"nETs\", anagrams))",
-      "message": " Assert EQ failed.  Expected ([len=1: failme]) == ([len=1: sent])",
+      "test_code": "h.assert_array_eq[String](failme, Anagram(\"nETs\", anagrams))",
+      "message": "Assert EQ failed.  Expected ([len=1: failme]) == ([len=1: sent])",
       "status": "fail",
-      "version": 2,
-      "name": "    // Anagram should be case insensitive"
+      "name": "Anagram should be case insensitive"
     },
     {
-      "test_code": "    h.assert_array_eq[String](failme, Anagram(\"seal\", anagrams))",
-      "message": " Assert EQ failed.  Expected ([len=1: failme]) == ([len=2: sale, ales])",
+      "test_code": "h.assert_array_eq[String](failme, Anagram(\"seal\", anagrams))",
+      "message": "Assert EQ failed.  Expected ([len=1: failme]) == ([len=2: sale, ales])",
       "status": "fail",
-      "version": 2,
-      "name": "    // Anagram should return multiple anagrams"
+      "name": "Anagram should return multiple anagrams"
     }
   ],
   "status": "fail",

--- a/tests/anagram-partial-fail/expected_results.json
+++ b/tests/anagram-partial-fail/expected_results.json
@@ -16,11 +16,10 @@
       "name": "    // Anagram shouldn't be based on checksum"
     },
     {
-      "test_code": "    h.assert_array_eq[String]([\"Sent\"], Anagram(\"nets\", anagrams))",
-      "message": " Assert EQ failed.  Expected ([len=1: Sent]) == ([len=1: sent])",
+      "test_code": "h.assert_array_eq[String]([\"Sent\"], Anagram(\"nets\", anagrams))",
+      "message": "Assert EQ failed.  Expected ([len=1: Sent]) == ([len=1: sent])",
       "status": "fail",
-      "version": 2,
-      "name": "    // Anagram should return an array of anagrams if present"
+      "name": "Anagram should return an array of anagrams if present"
     },
     {
       "test_code": "    h.assert_array_eq[String]([\"sent\"], Anagram(\"nETs\", anagrams))",


### PR DESCRIPTION
- Trimmed leading whitespaces and // in json responses.
- Removed redundant entries in .gitignore.
- Removed redundant version field in test results.
- Fix version of ponyc to 0.51.1